### PR TITLE
Fix Streamlit deployment error by disabling file watcher

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,2 +1,2 @@
 [server]
-folderWatchBlacklist = ['models']
+fileWatcherType = "none"


### PR DESCRIPTION
The application was failing to deploy on Streamlit Cloud due to an `OSError: [Errno 24] inotify instance limit reached` and subsequent segmentation faults.

This is a common issue when deploying Streamlit apps, as the file watcher can try to monitor too many files.

This change disables the file watcher by setting `server.fileWatcherType = "none"` in the Streamlit configuration file, which is the recommended solution for deployed applications.