### PR TITLE
Fix segmentation fault by downgrading TensorFlow and pinning Keras.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 streamlit==1.37.1           # latest stable
-tensorflow==2.20.0          # supports Python 3.13
+tensorflow==2.16.1          # Downgraded for stability
+keras==2.16.0               # Pinned for compatibility with TF 2.16.1
 Pillow==10.4.0              # latest, bugfixes
 google-generativeai==0.8.3  # latest Gemini SDK
 geopy==2.4.1


### PR DESCRIPTION
The application was crashing with a `Segmentation fault` after initializing TensorFlow. This was likely due to an incompatibility between the `tensorflow==2.20.0` version and the Streamlit Cloud execution environment.

This change downgrades `tensorflow` to `2.16.1` and pins `keras` to `2.16.0`. These versions are known to be more stable and should resolve the segmentation fault issue.