### PR TITLE
fix(model): Use session_state for robust model caching

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,18 +61,33 @@ except (KeyError, Exception) as e:
 # ====================================================================
 MODEL_DIR = os.path.join(os.getcwd(), "models")
 
-@st.cache_resource
 def load_plant_model():
+    """
+    Loads the plant disease model from disk and caches it in the session state
+    to avoid reloading on every script rerun.
+    """
+    # If model is already in session state, use it.
+    if 'plant_model' in st.session_state:
+        return st.session_state['plant_model']
+
+    # If model is not in session state, load it from disk.
     model_path = os.path.join(MODEL_DIR, "plant_disease_model.h5")
-    if not os.path.exists(model_path): return None
+    if not os.path.exists(model_path):
+        st.error("Plant disease model not found.")
+        return None
     try:
         model = load_model(model_path)
-        print("✅ Plant disease model loaded")
+        print("✅ Plant disease model loaded from disk.")
+        # Cache the model in the session state.
+        st.session_state['plant_model'] = model
         return model
     except Exception as e:
-        print(f"⚠️ Error loading plant disease model: {e}")
+        st.error(f"Error loading plant disease model: {e}")
+        # Ensure the model is set to None in session state on failure.
+        st.session_state['plant_model'] = None
         return None
 
+# Load the model (or get it from the session state cache).
 plant_model = load_plant_model()
 
 # ====================================================================


### PR DESCRIPTION
The plant disease prediction model was failing to load within the Streamlit app due to an incompatibility between the Keras 3 model object and the `@st.cache_resource` decorator. This caused the application to silently fail, making the model unavailable.

This commit replaces the problematic `@st.cache_resource` with a manual caching mechanism using `st.session_state`. This is a more robust and recommended pattern for handling complex objects like ML models in Streamlit.

The model is now loaded from disk once per user session and stored in the session state, which is both performant and reliable. This resolves the loading error and makes the plant disease prediction feature functional again.